### PR TITLE
Replaced the router internals with page.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ const router = ReactiveRouter({
   '/home': homeRouted,
   '/messages/:id': messageRouted,
   '/error': errorRouted
+}, {
+  hashbang: true
 });
 
 // Listen to state changes and set the url
@@ -126,7 +128,7 @@ const Comp = React.createClass({
 const Comp = React.createClass({
   render() {
     return (
-      <a href="#/messages/123">Open message 123</a>
+      <a href="/messages/123">Open message 123</a>
     );
   }
 });

--- a/index.js
+++ b/index.js
@@ -1,70 +1,27 @@
-const Router = function (routes) {
+const page = require('page');
 
-  var silent = false;
-  var matchRoutes = function (currentUrl) {
-    var fragments = currentUrl.split('/');
-    var result = Object.keys(routes).reduce(function (info, url) {
-      var length = url.split('/').length;
-      if (Router.match(currentUrl, url) && info.hit > info.currentHit) {
-        info.cb = routes[url];
-        info.currentHit = length;
-        info.params = Router.match(currentUrl, url);
-      }
-      return info;
-    }, {
-      cb: null,
-      currentHit: 0,
-      params: null,
-      hit: fragments.length
-    });
-    result.cb({
-      url: currentUrl,
-      params: result.params,
-      fragments: fragments
-    });
-  };
+const Router = function (routes, options) {
 
-  window.addEventListener('hashchange', function () {
-    if (silent) {
-      silent = false;
-      return;
-    }
-    matchRoutes(location.hash.substr(1));
+  // register the routes
+  Object.keys(routes).map(function (route) {
+    page(route, function (context) {
+      context.url = context.path;
+      context.fragments = context.pathname.split('/');
+      routes[route](context);
+    });
   });
-  matchRoutes(location.hash ? location.hash.substr(1) : '/');
 
+  // start the router
+  page(options || {});
+
+  // export functions
   return {
     set: function (url) {
-      if (url !== location.hash.substr(1)) {
-        location.hash = url;
-      }
-    },
-    setSilent: function (url) {
-      if (url !== location.hash.substr(1)) {
-        silent = true;
-        location.hash = url;
+      if (page.current !== url) {
+        page(url);
       }
     }
   };
-
-};
-
-Router.match = function (currentUrl, url) {
-
-  var currentArray = currentUrl.split('/');
-  var array = url.split('/');
-
-  var params = {};
-
-  for (var x = 0; x < array.length; x++) {
-    if (array[x] !== currentArray[x] && array[x][0] !== ':') {
-      return null;
-    }
-    if (array[x][0] === ':' && currentArray[x]) {
-      params[array[x].substr(1)] = currentArray[x];
-    }
-  }
-  return params;
 
 };
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cerebral-react-immutable-store": "^0.2.1",
     "immutable-store": "^0.5.1",
     "nodeunit": "^0.9.1",
+    "page": "^1.6.3",
     "react": "^0.13.3",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"


### PR DESCRIPTION
Not sure what the silent option was doing, but this seems to work without it.

Options can be passed to the router which are forwarded to page.js.

To switch over to pushstate simply remove the `hashbang: true` option.

`fragments` and `url` have been maintained to support existing stuff, but perhaps should be removed?
